### PR TITLE
Fix parameters for correctness computation

### DIFF
--- a/scripts/Kyber.py
+++ b/scripts/Kyber.py
@@ -41,9 +41,11 @@ def summarize(ps):
 
 if __name__ == "__main__":
     # Parameter sets
-    ps_light = KyberParameterSet(256, 2, 5, 5, 7681, 2**13, 2**11, 2**3)
-    ps_recommended = KyberParameterSet(256, 3, 4, 4, 7681, 2**13, 2**11, 2**3)
-    ps_paranoid = KyberParameterSet(256, 4, 3, 3, 7681, 2**13, 2**11, 2**3)
+    ps_light = KyberParameterSet(256, 2, 5, 5, 7681, 2**11, 2**11, 2**3)
+    ps_recommended = KyberParameterSet(256, 3, 4, 4, 7681, 2**11, 2**11, 2**3)
+    ps_paranoid = KyberParameterSet(256, 4, 3, 3, 7681, 2**11, 2**11, 2**3)
+    
+    
 
     # Analyses
     print ("Kyber512 (light):")


### PR DESCRIPTION
The Kyber.py script used the parameters (d_t, d_u, d_v) = (13, 11, 3) whereas the NIST-Submission uses (d_t, d_u, d_v) = (11, 11, 3).
This resulted in different correctness errors (2^-175 computed vs. 2^-142 stated in the submission-package for Kyber768).