### PR TITLE
cmake support added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set (K3 768)
 set (K4 1024)
 
 add_subdirectory(ref)
-# For the time being, don't build AVX2 on Win:
+# For the time being, don't build AVX2 on Win (ToDo!):
 if(NOT WIN32)
 add_subdirectory(avx2)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required (VERSION 3.5)
+# option() honors normal variables.
+# see: https://cmake.org/cmake/help/git-stage/policy/CMP0077.html
+if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
+# Honor symbol visibility properties for all target types.
+# see: https://cmake.org/cmake/help/git-stage/policy/CMP0063.html
+if(POLICY CMP0063)
+    cmake_policy(SET CMP0063 NEW)
+endif()
+
+
+project(kyber C ASM)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(WIN32)
+    set(CMAKE_GENERATOR_CC cl)
+    message("  In case of linkage problems be sure to select the proper architecture, e.g. via 'cmake -A x64 ..'")
+    message("  In case of runtime problems be sure to select Release config to avoid dev-dll problems, e.g. via 'msbuild ALL_BUILD.vcxproj /property:Configuration=Release'")
+    message("  In case of test problems be sure to output error messages, e.g., via 'ctest --output-on-failure -C Release'")
+else()
+include(FindUnixCommands)
+endif()
+
+# find openssl installation for test vector generation
+if(NOT DEFINED OPENSSL_ROOT_DIR)
+        if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
+            set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl@1.1")
+        elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
+            set(OPENSSL_ROOT_DIR "/usr")
+        endif()
+endif()
+find_package(OpenSSL 1.1.1 REQUIRED)
+include_directories(${OPENSSL_INCLUDE_DIR})
+
+enable_testing()
+
+# Kyber ID->"name" mapping
+set (K2 512)
+set (K3 768)
+set (K4 1024)
+
+add_subdirectory(ref)
+# For the time being, don't build AVX2 on Win:
+if(NOT WIN32)
+add_subdirectory(avx2)
+endif()
+
+add_library(kyber ${REF_OBJS} ${AVX2_OBJS})
+
+set(PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/ref/sign.h)
+
+set_target_properties(kyber
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    VERSION 0.1.0
+    SOVERSION 0
+    # For Windows DLLs
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+install(TARGETS kyber
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+install(FILES ${PUBLIC_HEADERS}
+        DESTINATION include/kyber)
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,25 @@
 [![Build Status](https://travis-ci.org/pq-crystals/kyber.svg?branch=master)](https://travis-ci.org/pq-crystals/kyber) [![Coverage Status](https://coveralls.io/repos/github/pq-crystals/kyber/badge.svg?branch=master)](https://coveralls.io/github/pq-crystals/kyber?branch=master)
 
 This directory contains our implementation of [Kyber](https://eprint.iacr.org/2017/634). Both the reference code and the AVX2 optimized code are in the directories ref/ and avx2/, respectively.
+
+## CMake
+
+Also available is a highly portable [cmake](https://cmake.org) based build system that permits building the same sources into a summary library as well as all the same tests.
+
+For fastest build performance, use of [Ninja](https://ninja-build.org) is recommended.
+
+All tests can be run by invoking the (your-favourite-build-tool-command-here) `test` target.
+
+### Worked example
+
+By calling 
+```
+mkdir build-ninja && cd build-ninja && cmake -DBUILD_SHARED_LIBS=ON -GNinja .. && ninja && ninja test
+```
+
+the whole Kyber software family gets built in a highly portable as well as an avx2-optimized version, tested and delivered in a shared library.
+
+For example, by running `./avx2/./avx2/test_speed512-90s_avx2` in the newly created 'build-ninja' folder, performance testing of `Kyber512-90s` in the optimized AVX2 variant is executed.
+
+The resultant library might also be installed using the `install` target.
+

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ For example, by running `./avx2/./avx2/test_speed512-90s_avx2` in the newly crea
 
 The resultant library might also be installed using the `install` target.
 
+Note: Testing on Windows has only been done using MSVS 2015 (cl version 19) and `msbuild`.

--- a/avx2/CMakeLists.txt
+++ b/avx2/CMakeLists.txt
@@ -1,0 +1,144 @@
+set(SRCS kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c)
+set(TEST_SRCS test_kyber.c randombytes.c)
+set(TESTKEX_SRCS test_kex.c randombytes.c kex.c)
+set(SPEED_SRCS test_speed.c speed_print.c cpucycles.c randombytes.c kex.c)
+set(VECTOR_SRCS test_vectors.c)
+set(PQCKAT_SRCS PQCgenKAT_kem.c rng.c)
+set(AES_FILES aes256ctr.c)
+set(KECCAK_FILES fips202x4.c keccak4x/KeccakP-1600-times4-SIMD256.c)
+set(AES_SRCS ${SRCS} symmetric-aes.c)
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+	add_compile_options(-O3)
+	add_compile_options(-Wall)
+	add_compile_options(-Wno-unused-result)
+	add_compile_options(-Wextra)
+	add_compile_options(-Wpedantic)
+	add_compile_options(-Wmissing-prototypes)
+	add_compile_options(-Wredundant-decls)
+	add_compile_options(-Wshadow)
+	add_compile_options(-Wpointer-arith)
+	add_compile_options(-mavx2)
+	add_compile_options(-mbmi2)
+	add_compile_options(-mpopcnt)
+	add_compile_options(-maes)
+	add_compile_options(-fomit-frame-pointer)
+
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	add_compile_options(-O3)
+	add_compile_options(-Wall)
+	add_compile_options(-Wextra)
+	add_compile_options(-Wno-unused-result)
+	add_compile_options(-Wpedantic)
+	add_compile_options(-Wmissing-prototypes)
+	add_compile_options(-Wredundant-decls)
+	add_compile_options(-Wshadow)
+	add_compile_options(-Wpointer-arith)
+	add_compile_options(-mavx2)
+	add_compile_options(-mbmi2)
+	add_compile_options(-mpopcnt)
+	add_compile_options(-maes)
+	add_compile_options(-fomit-frame-pointer)
+
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+	# Warning C4146 is raised when a unary minus operator is applied to an
+	# unsigned type; this has nonetheless been standard and portable for as
+	# long as there has been a C standard, and we need it for constant-time
+	# computations. Thus, we disable that spurious warning.
+	add_compile_options(/wd4146)
+endif()
+
+
+# First, do libraries:
+add_library(kyber_fips_avx2 OBJECT ${KECCAK_FILES} ${AES_FILES})
+set(_AVX2_OBJS $<TARGET_OBJECTS:kyber_fips_avx2>)
+
+# Plain tests
+foreach(X RANGE 2 4)
+   # Plain
+   add_library(kyber${X}lib_avx2 OBJECT ${SRCS} symmetric-shake.c)
+   target_compile_options(kyber${X}lib_avx2 PUBLIC -DKYBER_K=${X})
+   target_include_directories(kyber${X}lib_avx2 PRIVATE ${PROJECT_SOURCE_DIR}/avx2)
+   set(_AVX2_OBJS ${_AVX2_OBJS} $<TARGET_OBJECTS:kyber${X}lib_avx2>)
+
+   # Plain test
+   add_executable(test_kyber${K${X}}_avx2 ${TEST_SRCS})
+   target_link_libraries(test_kyber${K${X}}_avx2 PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_kyber${K${X}}_avx2 test_kyber${K${X}}_avx2)
+
+   # Plain KEX
+   add_executable(test_kex${K${X}}_avx2 ${TESTKEX_SRCS})
+   target_link_libraries(test_kex${K${X}}_avx2 PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_kex${K${{X}}_avx2 test_kex${K${X}}_avx2)
+
+   # Plain speed
+   if(NOT WIN32)
+   # Plain speed - not yet supported in Windows: TBD
+   add_executable(test_speed${K${X}}_avx2 ${SPEED_SRCS})
+   target_compile_options(test_speed${K${X}}_avx2 PUBLIC -DKYBER_K=${X})
+   target_link_libraries(test_speed${K${X}}_avx2 kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_speed${K${X}}_avx2 test_speed${K${X}}_avx2)
+   endif()
+
+   # Plain test vectors
+   add_executable(test_vectors${K${X}}_avx2 ${VECTOR_SRCS})
+   target_compile_options(test_vectors${K${X}}_avx2 PUBLIC -DKYBER_K=${X})
+   target_link_libraries(test_vectors${K${X}}_avx2 PRIVATE kyber ${OPENSSL_CRYPTO_LIBRARY})
+   if (WIN32) 
+      add_test(NAME test_vectors${X}_avx2 COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${K${X}}_avx2> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${K${X}}_avx2> | dos2unix > ../tvecs${K${X}}")
+   else()
+      add_test(NAME test_vectors${K${X}}_avx2 COMMAND sh -c "$<TARGET_FILE:test_vectors${K${X}}_avx2> > tvecs${K${X}}")
+   endif()
+
+   # AES
+   add_library(kyber${X}aeslib_avx2 OBJECT ${SRCS})
+   target_include_directories(kyber${X}aeslib_avx2 PRIVATE ${PROJECT_SOURCE_DIR}/avx2)
+   target_compile_options(kyber${X}aeslib_avx2 PUBLIC -DKYBER_K=${X} -DKYBER_90S)
+   set(_AVX2_OBJS ${_AVX2_OBJS} $<TARGET_OBJECTS:kyber${X}aeslib_avx2>)
+
+   # AES test
+   add_executable(test_kyber${K${X}}-90s_avx2 ${TEST_SRCS})
+   target_link_libraries(test_kyber${K${X}}-90s_avx2 PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_kyber${K${X}}-90s_avx2 test_kyber${K${X}}-90s_avx2)
+
+   # AES KEX
+   add_executable(test_kex${K${X}}-90s_avx2 ${TESTKEX_SRCS})
+   target_link_libraries(test_kex${K${X}}-90s_avx2 PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY} )
+   #add_test(test_kex${K${{X}}-90s_avx2 test_kex${K${X}}-90s_avx2)
+
+   # AES speed
+   if(NOT WIN32)
+   # Plain speed - not yet supported in Windows: TBD
+   add_executable(test_speed${K${X}}-90s_avx2 ${SPEED_SRCS})
+   target_compile_options(test_speed${K${X}}-90s_avx2 PUBLIC -DKYBER_K=${X} -DKYBER_90S)
+   target_link_libraries(test_speed${K${X}}-90s_avx2 kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_speed${K${X}}-90s_avx2 test_speed${K${X}}-90s_avx2)
+   endif()
+
+   # AES test vectors
+   add_executable(test_vectors${K${X}}-90s_avx2 ${VECTOR_SRCS})
+   target_compile_options(test_vectors${K${X}}-90s_avx2 PUBLIC -DKYBER_K=${X} -DKYBER_90S)
+   target_link_libraries(test_vectors${K${X}}-90s_avx2 PRIVATE kyber ${OPENSSL_CRYPTO_LIBRARY})
+   if (WIN32) 
+      add_test(NAME test_vectors${X}-90s_avx2 COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${K${X}}-90s_avx2> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${K${X}}-90s_avx2> | dos2unix > ../tvecs${K${X}}-90s")
+   else()
+      add_test(NAME test_vectors${K${X}}-90s_avx2 COMMAND sh -c "$<TARGET_FILE:test_vectors${K${X}}-90s_avx2> > tvecs${K${X}}-90s")
+   endif()
+
+endforeach()
+
+# PQCKATs
+add_executable(PQCgenKAT_kem_avx2 ${PQCKAT_SRCS})
+target_compile_options(PQCgenKAT_kem_avx2 PUBLIC)
+target_link_libraries(PQCgenKAT_kem_avx2 PRIVATE kyber ${OPENSSL_CRYPTO_LIBRARY})
+if (WIN32) 
+      # Necessary cludge to make hashes be ignorant of Windows CRLF file formatting:
+      add_test(NAME PQCgenKAT_kem_avx2 COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:PQCgenKAT_kem_avx2> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:PQCgenKAT_kem_avx2> && dos2unix -n PQCsignKAT_KEM.rsp ../PQCsignKAT_KEM.rsp && dos2unix -n PQCsignKAT_KEM.req ../PQCsignKAT_KEM.req")
+else()
+      add_test(PQCgenKAT_kem_avx2 PQCgenKAT_kem_avx2)
+endif()
+
+add_test(Hashes_test_avx2 sha256sum -c ../../SHA256SUMS)
+
+set(AVX2_OBJS ${_AVX2_OBJS} PARENT_SCOPE)
+

--- a/avx2/CMakeLists.txt
+++ b/avx2/CMakeLists.txt
@@ -53,9 +53,9 @@ endif()
 add_library(kyber_fips_avx2 OBJECT ${KECCAK_FILES} ${AES_FILES})
 set(_AVX2_OBJS $<TARGET_OBJECTS:kyber_fips_avx2>)
 
-# Plain tests
+# Iterate over parameter sets:
 foreach(X RANGE 2 4)
-   # Plain
+   # Plain Kyber
    add_library(kyber${X}lib_avx2 OBJECT ${SRCS} symmetric-shake.c)
    target_compile_options(kyber${X}lib_avx2 PUBLIC -DKYBER_K=${X})
    target_include_directories(kyber${X}lib_avx2 PRIVATE ${PROJECT_SOURCE_DIR}/avx2)
@@ -90,7 +90,7 @@ foreach(X RANGE 2 4)
       add_test(NAME test_vectors${K${X}}_avx2 COMMAND sh -c "$<TARGET_FILE:test_vectors${K${X}}_avx2> > tvecs${K${X}}")
    endif()
 
-   # AES
+   # AES Kyber ('90s')
    add_library(kyber${X}aeslib_avx2 OBJECT ${SRCS})
    target_include_directories(kyber${X}aeslib_avx2 PRIVATE ${PROJECT_SOURCE_DIR}/avx2)
    target_compile_options(kyber${X}aeslib_avx2 PUBLIC -DKYBER_K=${X} -DKYBER_90S)

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -1,0 +1,133 @@
+set(SRCS kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c)
+set(TEST_SRCS test_kyber.c randombytes.c)
+set(TESTKEX_SRCS test_kex.c randombytes.c kex.c)
+set(SPEED_SRCS test_speed.c speed_print.c cpucycles.c randombytes.c kex.c)
+set(VECTOR_SRCS test_vectors.c)
+set(PQCKAT_SRCS PQCgenKAT_kem.c rng.c)
+set(AES_FILES aes256ctr.c)
+set(KECCAK_FILES fips202.c sha256.c sha512.c)
+set(AES_SRCS ${SRCS} symmetric-aes.c)
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+	add_compile_options(-g)
+	add_compile_options(-Wall)
+	add_compile_options(-Wno-unused-result)
+	add_compile_options(-Wextra)
+	add_compile_options(-Wpedantic)
+	add_compile_options(-Wmissing-prototypes)
+	add_compile_options(-Wredundant-decls)
+	add_compile_options(-Wshadow)
+	add_compile_options(-Wpointer-arith)
+
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	#add_compile_options(-Werror)
+	add_compile_options(-Wall)
+	add_compile_options(-Wextra)
+	add_compile_options(-Wno-unused-result)
+	add_compile_options(-Wpedantic)
+	add_compile_options(-Wmissing-prototypes)
+	add_compile_options(-Wredundant-decls)
+	add_compile_options(-Wshadow)
+	add_compile_options(-Wpointer-arith)
+	add_compile_options(-O3)
+
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+	# Warning C4146 is raised when a unary minus operator is applied to an
+	# unsigned type; this has nonetheless been standard and portable for as
+	# long as there has been a C standard, and we need it for constant-time
+	# computations. Thus, we disable that spurious warning.
+	add_compile_options(/wd4146)
+endif()
+
+
+# First, do libraries:
+add_library(kyber_fips_ref OBJECT ${KECCAK_FILES} ${AES_FILES})
+set(_REF_OBJS $<TARGET_OBJECTS:kyber_fips_ref>)
+
+# Plain tests
+foreach(X RANGE 2 4)
+   # Plain
+   add_library(kyber${X}lib_ref OBJECT ${SRCS} symmetric-shake.c)
+   target_compile_options(kyber${X}lib_ref PUBLIC -DKYBER_K=${X})
+   set(_REF_OBJS ${_REF_OBJS} $<TARGET_OBJECTS:kyber${X}lib_ref>)
+
+   # Plain test
+   add_executable(test_kyber${K${X}}_ref ${TEST_SRCS})
+   target_link_libraries(test_kyber${K${X}}_ref PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_kyber${K${X}}_ref test_kyber${K${X}}_ref)
+
+   # Plain KEX
+   add_executable(test_kex${K${X}}_ref ${TESTKEX_SRCS})
+   target_link_libraries(test_kex${K${X}}_ref PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_kex${K${{X}}_ref test_kex${K${X}}_ref)
+
+   # Plain speed
+   if(NOT WIN32)
+   # Plain speed - not yet supported in Windows: TBD
+   add_executable(test_speed${K${X}}_ref ${SPEED_SRCS})
+   target_compile_options(test_speed${K${X}}_ref PUBLIC -DKYBER_K=${X})
+   target_link_libraries(test_speed${K${X}}_ref kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_speed${K${X}}_ref test_speed${K${X}}_ref)
+   endif()
+
+   # Plain test vectors
+   add_executable(test_vectors${K${X}}_ref ${VECTOR_SRCS})
+   target_compile_options(test_vectors${K${X}}_ref PUBLIC -DKYBER_K=${X})
+   target_link_libraries(test_vectors${K${X}}_ref PRIVATE kyber ${OPENSSL_CRYPTO_LIBRARY})
+   if (WIN32) 
+      add_test(NAME test_vectors${X}_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${K${X}}_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${K${X}}_ref> | dos2unix > ../tvecs${K${X}}")
+   else()
+      add_test(NAME test_vectors${K${X}}_ref COMMAND sh -c "$<TARGET_FILE:test_vectors${K${X}}_ref> > tvecs${K${X}}")
+   endif()
+
+   # AES
+   add_library(kyber${X}aeslib_ref OBJECT ${SRCS} symmetric-aes.c)
+   target_compile_options(kyber${X}aeslib_ref PUBLIC -DKYBER_K=${X} -DKYBER_90S)
+   set(_REF_OBJS ${_REF_OBJS} $<TARGET_OBJECTS:kyber${X}aeslib_ref>)
+
+   # AES test
+   add_executable(test_kyber${K${X}}-90s_ref ${TEST_SRCS})
+   target_link_libraries(test_kyber${K${X}}-90s_ref PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_kyber${K${X}}-90s_ref test_kyber${K${X}}-90s_ref)
+
+   # AES KEX
+   add_executable(test_kex${K${X}}-90s_ref ${TESTKEX_SRCS})
+   target_link_libraries(test_kex${K${X}}-90s_ref PUBLIC kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_kex${K${{X}}-90s_ref test_kex${K${X}}-90s_ref)
+
+   # AES speed
+   if(NOT WIN32)
+   # AES speed - not yet supported in Windows: TBD
+   add_executable(test_speed${K${X}}-90s_ref ${SPEED_SRCS})
+   target_compile_options(test_speed${K${X}}-90s_ref PUBLIC -DKYBER_K=${X} -DKYBER_90S)
+   target_link_libraries(test_speed${K${X}}-90s_ref kyber ${OPENSSL_CRYPTO_LIBRARY})
+   #add_test(test_speed${K${X}}-90s_ref test_speed${K${X}}-90s_ref)
+   endif()
+
+   # AES test vectors
+   add_executable(test_vectors${K${X}}-90s_ref ${VECTOR_SRCS})
+   target_compile_options(test_vectors${K${X}}-90s_ref PUBLIC -DKYBER_K=${X} -DKYBER_90S)
+   target_link_libraries(test_vectors${K${X}}-90s_ref PRIVATE kyber ${OPENSSL_CRYPTO_LIBRARY})
+   if (WIN32) 
+      add_test(NAME test_vectors${X}-90s_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${K${X}}-90s_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${K${X}}-90s_ref> | dos2unix > ../tvecs${K${X}}-90s")
+   else()
+      add_test(NAME test_vectors${K${X}}-90s_ref COMMAND sh -c "$<TARGET_FILE:test_vectors${K${X}}-90s_ref> > tvecs${K${X}}-90s")
+   endif()
+
+endforeach()
+
+# PQCKATs
+add_executable(PQCgenKAT_kem_ref ${PQCKAT_SRCS})
+target_compile_options(PQCgenKAT_kem_ref PUBLIC)
+target_link_libraries(PQCgenKAT_kem_ref PRIVATE kyber ${OPENSSL_CRYPTO_LIBRARY})
+if (WIN32) 
+      # Necessary cludge to make hashes be ignorant of Windows CRLF file formatting:
+      add_test(NAME PQCgenKAT_kem_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:PQCgenKAT_kem_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:PQCgenKAT_kem_ref> && dos2unix -n PQCsignKAT_KEM.rsp ../PQCsignKAT_KEM.rsp && dos2unix -n PQCsignKAT_KEM.req ../PQCsignKAT_KEM.req")
+else()
+      add_test(PQCgenKAT_kem_ref PQCgenKAT_kem_ref)
+endif()
+
+add_test(Hashes_test_ref sha256sum -c ../../SHA256SUMS)
+
+set(REF_OBJS ${_REF_OBJS} PARENT_SCOPE)
+message("Ref objects: ${REF_OBJS}")

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -44,9 +44,9 @@ endif()
 add_library(kyber_fips_ref OBJECT ${KECCAK_FILES} ${AES_FILES})
 set(_REF_OBJS $<TARGET_OBJECTS:kyber_fips_ref>)
 
-# Plain tests
+# Iterate over parameter sets:
 foreach(X RANGE 2 4)
-   # Plain
+   # Plain Kyber
    add_library(kyber${X}lib_ref OBJECT ${SRCS} symmetric-shake.c)
    target_compile_options(kyber${X}lib_ref PUBLIC -DKYBER_K=${X})
    set(_REF_OBJS ${_REF_OBJS} $<TARGET_OBJECTS:kyber${X}lib_ref>)
@@ -80,7 +80,7 @@ foreach(X RANGE 2 4)
       add_test(NAME test_vectors${K${X}}_ref COMMAND sh -c "$<TARGET_FILE:test_vectors${K${X}}_ref> > tvecs${K${X}}")
    endif()
 
-   # AES
+   # AES Kyber ('90s')
    add_library(kyber${X}aeslib_ref OBJECT ${SRCS} symmetric-aes.c)
    target_compile_options(kyber${X}aeslib_ref PUBLIC -DKYBER_K=${X} -DKYBER_90S)
    set(_REF_OBJS ${_REF_OBJS} $<TARGET_OBJECTS:kyber${X}aeslib_ref>)
@@ -130,4 +130,3 @@ endif()
 add_test(Hashes_test_ref sha256sum -c ../../SHA256SUMS)
 
 set(REF_OBJS ${_REF_OBJS} PARENT_SCOPE)
-message("Ref objects: ${REF_OBJS}")


### PR DESCRIPTION
Introducing cmake to Kyber.

README extended. Testing target available. Windows limitations (no speed, no avx2 support and testing errors comparable to the ones that dilithium showed (sending log via separate mail; it would be great if you'd find time time to do similar updates as done for dilithium to make this pass too).