### PR TITLE
Fix target features

### DIFF
--- a/avx2/Makefile
+++ b/avx2/Makefile
@@ -1,8 +1,8 @@
 CC ?= /usr/bin/cc
 CFLAGS += -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls \
-  -Wshadow -Wpointer-arith -mavx2 -mbmi -mpopcnt -maes \
-  -march=native -mtune=native -O3 -fomit-frame-pointer
-NISTFLAGS += -Wno-unused-result -mavx2 -mbmi -mpopcnt -maes \
+  -Wshadow -Wpointer-arith -mavx2 -mbmi2 -mpopcnt -maes \
+  -O3 -fomit-frame-pointer
+NISTFLAGS += -Wno-unused-result -mavx2 -mbmi2 -mpopcnt -maes \
   -march=native -mtune=native -O3
 RM = /bin/rm
 


### PR DESCRIPTION
`rejsample.c` uses `pext`, a `bmi2` feature. This was hidden by `-march.`