### PR TITLE
Fix signed integer overflow in montgomery_reduce()

### DIFF
--- a/ref/reduce.c
+++ b/ref/reduce.c
@@ -19,7 +19,7 @@ int16_t montgomery_reduce(int32_t a)
   int32_t t;
   int16_t u;
 
-  u = a*QINV;
+  u = (int16_t)(a*(int64_t)QINV);
   t = (int32_t)u*KYBER_Q;
   t = a - t;
   t >>= 16;


### PR DESCRIPTION
This fixes errors like the below, that randomly occur when running with `-fsanitize=undefined`.

```
reduce.c:21:11: runtime error: signed integer overflow: -4752000 * 62209 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior reduce.c:21:11 in
```