### PR TITLE
Remove a Barrett reduction during keygen and decryption

### DIFF
--- a/ref/indcpa.c
+++ b/ref/indcpa.c
@@ -230,6 +230,7 @@ void indcpa_keypair(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
     poly_getnoise(&e.vec[i], noiseseed, nonce++);
 
   polyvec_ntt(&skpv);
+  polyvec_reduce(&skpv);
   polyvec_ntt(&e);
 
   // matrix-vector multiplication
@@ -284,6 +285,7 @@ void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
   poly_getnoise(&epp, coins, nonce++);
 
   polyvec_ntt(&sp);
+  polyvec_reduce(&sp);
 
   // matrix-vector multiplication
   for(i=0;i<KYBER_K;i++)
@@ -327,6 +329,7 @@ void indcpa_dec(uint8_t m[KYBER_INDCPA_MSGBYTES],
   unpack_sk(&skpv, sk);
 
   polyvec_ntt(&bp);
+  polyvec_reduce(&bp);
   polyvec_pointwise_acc_montgomery(&mp, &skpv, &bp);
   poly_invntt_tomont(&mp);
 

--- a/ref/indcpa.c
+++ b/ref/indcpa.c
@@ -329,7 +329,10 @@ void indcpa_dec(uint8_t m[KYBER_INDCPA_MSGBYTES],
   unpack_sk(&skpv, sk);
 
   polyvec_ntt(&bp);
-  polyvec_reduce(&bp);
+
+  // skpv is bounded in absolute value by 2^12.  bp is bounded in absolute
+  // value by 7q.  Multiplied the coefficients are bounded by 2^14.9q,
+  // which is below the 2^15q required for the Montgomery reduction.
   polyvec_pointwise_acc_montgomery(&mp, &skpv, &bp);
   poly_invntt_tomont(&mp);
 

--- a/ref/poly.c
+++ b/ref/poly.c
@@ -243,7 +243,6 @@ void poly_getnoise(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce)
 void poly_ntt(poly *r)
 {
   ntt(r->coeffs);
-  poly_reduce(r);
 }
 
 /*************************************************


### PR DESCRIPTION
For keygen, coefficients of e are bounded in absolute value by 7q (NTT). Those of
pkpv are bounded in absolute value by q (to_mont).  Thus Barrett
reducing e before adding it to pkpv is unnecessary.

For decryption skpv is bounded in absolute value by 2^12.  bp is bounded in absolute
value by 7q.  Multiplied the coefficients are bounded by 2^14.9q,
which is below the 2^15q required for the Montgomery reduction.

This only changes the ref code.  I'll leave the avx2 changes to you.