### PR TITLE
Don't use boolean operations in assignments

### DIFF
--- a/avx2/verify.c
+++ b/avx2/verify.c
@@ -27,7 +27,7 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len)
     avec = _mm256_xor_si256(avec, bvec);
     cvec = _mm256_or_si256(cvec, avec);
   }
-  r = !_mm256_testz_si256(cvec,cvec);
+  r = 1 - _mm256_testz_si256(cvec,cvec);
 
   if(pos < len) {
     avec = _mm256_loadu_si256((__m256i *)&a[pos]);


### PR DESCRIPTION
These are better avoided, John Schanck found that these may generate non-constant time code on some compilers

See https://github.com/PQClean/PQClean/pull/325#issue-486686614