### PR TITLE
fix aes256ctr_prf() in avx2 version

### DIFF
--- a/avx2/aes256ctr.c
+++ b/avx2/aes256ctr.c
@@ -138,6 +138,7 @@ void aes256ctr_prf(uint8_t *out,
   while(outlen >= 64) {
     aesni_encrypt4(out, &state.n, state.rkeys);
     outlen -= 64;
+    out += 64;
   }
 
   if(outlen) {


### PR DESCRIPTION
out pointer was not updated during the while loop.