### PR TITLE
Fixed shift overflow for 32-bit builds

### DIFF
--- a/ref/sha256.c
+++ b/ref/sha256.c
@@ -231,7 +231,7 @@ void sha256(uint8_t *out,const uint8_t *in,size_t inlen)
   uint8_t h[32];
   uint8_t padded[128];
   unsigned int i;
-  size_t bits = inlen << 3;
+  uint64_t bits = inlen << 3;
 
   for (i = 0;i < 32;++i) h[i] = iv[i];
 

--- a/ref/sha512.c
+++ b/ref/sha512.c
@@ -260,7 +260,7 @@ void sha512(uint8_t *out,const uint8_t *in,size_t inlen)
   uint8_t h[64];
   uint8_t padded[256];
   unsigned int i;
-  size_t bytes = inlen;
+  uint64_t bytes = inlen;
 
   for (i = 0;i < 64;++i) h[i] = iv[i];
 


### PR DESCRIPTION
`bits` and `bytes` have to be at least 64-bit wide to avoid overflows when shifting them later. For 32-bit builds, `size_t` is not big enough.