### PR TITLE
Preparing automatic pull for liboqs.

### DIFF
--- a/Kyber1024-90s_META.yml
+++ b/Kyber1024-90s_META.yml
@@ -1,12 +1,12 @@
 name: Kyber1024-90s
 type: kem
-claimed-nist-level: 1
+claimed-nist-level: 5
 claimed-security: IND-CCA2
 length-public-key: 1568
 length-ciphertext: 1568
 length-secret-key: 3168
 length-shared-secret: 32
-nistkat-sha256: 0aae7ad05d260939e1235906598c04d4120e25c608c2189de90d4d026eb8101b
+nistkat-sha256: a1b564348a126a118fbc49a6aeaebcb74896753fd99f30eeb0f75f0b2d25115f
 testvectors-sha256: f547f5361f933e6489d2385524ffd36893063c6b9cc3f921514b4ebb9daefdaa
 principal-submitters:
   - Peter Schwabe
@@ -21,29 +21,28 @@ auxiliary-submitters:
   - Gregor Seiler
   - Damien Stehlé
 implementations:
-  - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    folder_name: ref
-    compile_opts: -DKYBER_K=4 -DKYBER_90S
-    signature_keypair: pqcrystals_kyber1024_90s_ref_keypair
-    signature_enc: pqcrystals_kyber1024_90s_ref_enc
-    signature_dec: pqcrystals_kyber1024_90s_ref_dec
-    sources: api.h params.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h cbd.c cbd.h reduce.c reduce.h verify.c verify.h symmetric-aes.c symmetric.h
-
-  - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    compile_opts: -DKYBER_K=4 -DKYBER_90S
-    signature_keypair: pqcrystals_kyber1024_90s_avx2_keypair
-    signature_enc: pqcrystals_kyber1024_90s_avx2_enc
-    signature_dec: pqcrystals_kyber1024_90s_avx2_dec
-    sources: api.h params.h align.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S basemul.S ntt.h fq.S fq.inc reduce.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h cbd.c cbd.h verify.c verify.h symmetric-aes.c symmetric.h
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Linux
-          - Darwin
-        required_flags:
-          - avx2
-          - aes
-          - bmi2
-          - popcnt
+    - name: ref
+      version: https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b
+      folder_name: ref
+      compile_opts: -DKYBER_K=4 -DKYBER_90S
+      signature_keypair: pqcrystals_kyber1024_90s_ref_keypair
+      signature_enc: pqcrystals_kyber1024_90s_ref_enc
+      signature_dec: pqcrystals_kyber1024_90s_ref_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h aes256ctr.c symmetric-aes.c
+    - name: avx2
+      version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
+      compile_opts: -DKYBER_K=4 -DKYBER_90S
+      signature_keypair: pqcrystals_kyber1024_90s_avx2_keypair
+      signature_enc: pqcrystals_kyber1024_90s_avx2_enc
+      signature_dec: pqcrystals_kyber1024_90s_avx2_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h aes256ctr.c
+      supported_platforms:
+        - architecture: x86_64
+          operating_systems:
+            - Linux
+            - Darwin
+          required_flags:
+              - aes
+              - avx2
+              - bmi2
+              - popcnt

--- a/Kyber1024_META.yml
+++ b/Kyber1024_META.yml
@@ -1,12 +1,12 @@
 name: Kyber1024
 type: kem
-claimed-nist-level: 1
+claimed-nist-level: 5
 claimed-security: IND-CCA2
 length-public-key: 1568
 length-ciphertext: 1568
 length-secret-key: 3168
 length-shared-secret: 32
-nistkat-sha256: 89248f2f33f7f4f7051729111f3049c409a933ec904aedadf035f30fa5646cd5
+nistkat-sha256: 5afcf2a568ad32d49b55105b032af1850f03f3888ff9e2a72f4059c58e968f60
 testvectors-sha256: ff1a854b9b6761a70c65ccae85246fe0596a949e72eae0866a8a2a2d4ea54b10
 principal-submitters:
   - Peter Schwabe
@@ -21,29 +21,27 @@ auxiliary-submitters:
   - Gregor Seiler
   - Damien Stehlé
 implementations:
-  - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    folder_name: ref
-    compile_opts: -DKYBER_K=4
-    signature_keypair: pqcrystals_kyber1024_ref_keypair
-    signature_enc: pqcrystals_kyber1024_ref_enc
-    signature_dec: pqcrystals_kyber1024_ref_dec
-    sources: api.h params.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h cbd.c cbd.h reduce.c reduce.h verify.c verify.h symmetric-shake.c symmetric.h
-
-  - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    compile_opts: -DKYBER_K=4
-    signature_keypair: pqcrystals_kyber1024_avx2_keypair
-    signature_enc: pqcrystals_kyber1024_avx2_enc
-    signature_dec: pqcrystals_kyber1024_avx2_dec
-    sources: api.h params.h align.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S basemul.S ntt.h fq.S fq.inc reduce.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h cbd.c cbd.h verify.c verify.h symmetric-shake.c symmetric.h
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Linux
-          - Darwin
-        required_flags:
-          - avx2
-          - aes
-          - bmi2
-          - popcnt
+    - name: ref
+      version: https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b
+      folder_name: ref
+      compile_opts: -DKYBER_K=4
+      signature_keypair: pqcrystals_kyber1024_ref_keypair
+      signature_enc: pqcrystals_kyber1024_ref_enc
+      signature_dec: pqcrystals_kyber1024_ref_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
+    - name: avx2
+      version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
+      compile_opts: -DKYBER_K=4
+      signature_keypair: pqcrystals_kyber1024_avx2_keypair
+      signature_enc: pqcrystals_kyber1024_avx2_enc
+      signature_dec: pqcrystals_kyber1024_avx2_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h fips202x4.c keccak4x symmetric-shake.c
+      supported_platforms:
+        - architecture: x86_64
+          operating_systems:
+            - Linux
+            - Darwin
+          required_flags:
+            - avx2
+            - bmi2
+            - popcnt

--- a/Kyber512-90s_META.yml
+++ b/Kyber512-90s_META.yml
@@ -6,7 +6,7 @@ length-public-key: 800
 length-ciphertext: 768
 length-secret-key: 1632
 length-shared-secret: 32
-nistkat-sha256: a3d271762446e5d0996aef8e8a76e714dce2ece7e0354c77212a86f398f4cf52
+nistkat-sha256: 7bfe0653b63b3fac7ee300a6e4801046c1a3d8d445b271633b6c9d81ed125e5b
 testvectors-sha256: 2ea81fa2d7e3c1970409b9d77d6c5137aeb4573e856ca79eab4393b70352e85b
 principal-submitters:
   - Peter Schwabe
@@ -21,29 +21,28 @@ auxiliary-submitters:
   - Gregor Seiler
   - Damien Stehlé
 implementations:
-  - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    folder_name: ref
-    compile_opts: -DKYBER_K=2 -DKYBER_90S
-    signature_keypair: pqcrystals_kyber512_90s_ref_keypair
-    signature_enc: pqcrystals_kyber512_90s_ref_enc
-    signature_dec: pqcrystals_kyber512_90_ref_dec
-    sources: api.h params.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h cbd.c cbd.h reduce.c reduce.h verify.c verify.h symmetric-aes.c symmetric.h
-
-  - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    compile_opts: -DKYBER_K=2 -DKYBER_90s
-    signature_keypair: pqcrystals_kyber512_90s_avx2_keypair
-    signature_enc: pqcrystals_kyber512_90s_avx2_enc
-    signature_dec: pqcrystals_kyber512_90s_avx2_dec
-    sources: api.h params.h align.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S basemul.S ntt.h fq.S fq.inc reduce.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h cbd.c cbd.h verify.c verify.h symmetric-aes.c symmetric.h
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Linux
-          - Darwin
-        required_flags:
-          - avx2
-          - aes
-          - bmi2
-          - popcnt
+    - name: ref
+      version: https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b
+      folder_name: ref
+      compile_opts: -DKYBER_K=2 -DKYBER_90S
+      signature_keypair: pqcrystals_kyber512_90s_ref_keypair
+      signature_enc: pqcrystals_kyber512_90s_ref_enc
+      signature_dec: pqcrystals_kyber512_90s_ref_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h aes256ctr.c symmetric-aes.c
+    - name: avx2
+      version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
+      compile_opts: -DKYBER_K=2 -DKYBER_90S
+      signature_keypair: pqcrystals_kyber512_90s_avx2_keypair
+      signature_enc: pqcrystals_kyber512_90s_avx2_enc
+      signature_dec: pqcrystals_kyber512_90s_avx2_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h aes256ctr.c
+      supported_platforms:
+          - architecture: x86_64
+            operating_systems:
+                - Linux
+                - Darwin
+            required_flags:
+                - aes
+                - avx2
+                - bmi2
+                - popcnt

--- a/Kyber512_META.yml
+++ b/Kyber512_META.yml
@@ -6,7 +6,7 @@ length-public-key: 800
 length-ciphertext: 768
 length-secret-key: 1632
 length-shared-secret: 32
-nistkat-sha256: e9c2bd37133fcb40772f81559f14b1f58dccd1c816701be9ba6214d43baf4547
+nistkat-sha256: bb0481d3325d828817900b709d23917cefbc10026fc857f098979451f67bb0ca
 testvectors-sha256: 6730bb552c22d9d2176ffb5568e48eb30952cf1f065073ec5f9724f6a3c6ea85
 principal-submitters:
   - Peter Schwabe
@@ -21,29 +21,27 @@ auxiliary-submitters:
   - Gregor Seiler
   - Damien Stehlé
 implementations:
-  - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    folder_name: ref
-    compile_opts: -DKYBER_K=2
-    signature_keypair: pqcrystals_kyber512_ref_keypair
-    signature_enc: pqcrystals_kyber512_ref_enc
-    signature_dec: pqcrystals_kyber512_ref_dec
-    sources: api.h params.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h cbd.c cbd.h reduce.c reduce.h verify.c verify.h symmetric-shake.c symmetric.h
-
-  - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    compile_opts: -DKYBER_K=2
-    signature_keypair: pqcrystals_kyber512_avx2_keypair
-    signature_enc: pqcrystals_kyber512_avx2_enc
-    signature_dec: pqcrystals_kyber512_avx2_dec
-    sources: api.h params.h align.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S basemul.S ntt.h fq.S fq.inc reduce.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h cbd.c cbd.h verify.c verify.h symmetric-shake.c symmetric.h
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Linux
-          - Darwin
-        required_flags:
-          - avx2
-          - aes
-          - bmi2
-          - popcnt
+    - name: ref
+      version: https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b
+      folder_name: ref
+      compile_opts: -DKYBER_K=2 
+      signature_keypair: pqcrystals_kyber512_ref_keypair
+      signature_enc: pqcrystals_kyber512_ref_enc
+      signature_dec: pqcrystals_kyber512_ref_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
+    - name: avx2
+      version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
+      compile_opts: -DKYBER_K=2 
+      signature_keypair: pqcrystals_kyber512_avx2_keypair
+      signature_enc: pqcrystals_kyber512_avx2_enc
+      signature_dec: pqcrystals_kyber512_avx2_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h fips202x4.c keccak4x symmetric-shake.c
+      supported_platforms:
+        - architecture: x86_64
+          operating_systems:
+            - Linux
+            - Darwin
+          required_flags:
+            - avx2
+            - bmi2
+            - popcnt

--- a/Kyber768-90s_META.yml
+++ b/Kyber768-90s_META.yml
@@ -6,7 +6,7 @@ length-public-key: 1184
 length-ciphertext: 1088
 length-secret-key: 2400
 length-shared-secret: 32
-nistkat-sha256: 890176520882068007cdcc009d7651cd11c4e54b443df131ad12340e61ddd8e6
+nistkat-sha256: 68bf2e3914c0b4e053cefc67dd9f10f567946da5720f0b453b347610c3cc2c0a
 testvectors-sha256: a1b8fe37e3fc58a8511c63a7187d3626a1a98c5d3bb67000fe9a02be7199d952
 principal-submitters:
   - Peter Schwabe
@@ -21,29 +21,28 @@ auxiliary-submitters:
   - Gregor Seiler
   - Damien Stehlé
 implementations:
-  - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    folder_name: ref
-    compile_opts: -DKYBER_K=3 -DKYBER_90S
-    signature_keypair: pqcrystals_kyber768_90s_ref_keypair
-    signature_enc: pqcrystals_kyber768_90s_ref_enc
-    signature_dec: pqcrystals_kyber768_90s_ref_dec
-    sources: api.h params.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h cbd.c cbd.h reduce.c reduce.h verify.c verify.h symmetric-aes.c symmetric.h
-
-  - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    compile_opts: -DKYBER_K=3 -DKYBER_90S
-    signature_keypair: pqcrystals_kyber768_90s_avx2_keypair
-    signature_enc: pqcrystals_kyber768_90s_avx2_enc
-    signature_dec: pqcrystals_kyber768_90s_avx2_dec
-    sources: api.h params.h align.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S basemul.S ntt.h fq.S fq.inc reduce.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h cbd.c cbd.h verify.c verify.h symmetric-aes.c symmetric.h
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Linux
-          - Darwin
-        required_flags:
-          - avx2
-          - aes
-          - bmi2
-          - popcnt
+    - name: ref
+      version: https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b
+      folder_name: ref
+      compile_opts: -DKYBER_K=3 -DKYBER_90S
+      signature_keypair: pqcrystals_kyber768_90s_ref_keypair
+      signature_enc: pqcrystals_kyber768_90s_ref_enc
+      signature_dec: pqcrystals_kyber768_90s_ref_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h aes256ctr.c symmetric-aes.c
+    - name: avx2
+      version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
+      compile_opts: -DKYBER_K=3 -DKYBER_90S
+      signature_keypair: pqcrystals_kyber768_90s_avx2_keypair
+      signature_enc: pqcrystals_kyber768_90s_avx2_enc
+      signature_dec: pqcrystals_kyber768_90s_avx2_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h aes256ctr.c
+      supported_platforms:
+        - architecture: x86_64
+          operating_systems:
+            - Linux
+            - Darwin
+          required_flags:
+            - aes
+            - avx2
+            - bmi2
+            - popcnt

--- a/Kyber768_META.yml
+++ b/Kyber768_META.yml
@@ -1,12 +1,12 @@
 name: Kyber768
 type: kem
-claimed-nist-level: 1
+claimed-nist-level: 3
 claimed-security: IND-CCA2
 length-public-key: 1184
 length-ciphertext: 1088
 length-secret-key: 2400
 length-shared-secret: 32
-nistkat-sha256: a1e122cad3c24bc51622e4c242d8b8acbcd3f618fee4220400605ca8f9ea02c2
+nistkat-sha256: 89e82a5bf2d4ddb2c6444e10409e6d9ca65dafbca67d1a0db2c9b54920a29172
 testvectors-sha256: 667c8ca2ca93729c0df6ff24588460bad1bbdbfb64ece0fe8563852a7ff348c6
 principal-submitters:
   - Peter Schwabe
@@ -21,29 +21,27 @@ auxiliary-submitters:
   - Gregor Seiler
   - Damien Stehlé
 implementations:
-  - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    folder_name: ref
-    compile_opts: -DKYBER_K=3
-    signature_keypair: pqcrystals_kyber768_ref_keypair
-    signature_enc: pqcrystals_kyber768_ref_enc
-    signature_dec: pqcrystals_kyber768_ref_dec
-    sources: api.h params.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h cbd.c cbd.h reduce.c reduce.h verify.c verify.h symmetric-shake.c symmetric.h
-
-  - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/afa4b9bfb7266e32829502ebaa9e20ca0551e1bd
-    compile_opts: -DKYBER_K=3
-    signature_keypair: pqcrystals_kyber768_avx2_keypair
-    signature_enc: pqcrystals_kyber768_avx2_enc
-    signature_dec: pqcrystals_kyber768_avx2_dec
-    sources: api.h params.h align.h kem.c kem.h indcpa.c indcpa.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S basemul.S ntt.h fq.S fq.inc reduce.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h cbd.c cbd.h verify.c verify.h symmetric-shake.c symmetric.h
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Linux
-          - Darwin
-        required_flags:
-          - avx2
-          - aes
-          - bmi2
-          - popcnt
+    - name: ref
+      version: https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b
+      folder_name: ref
+      compile_opts: -DKYBER_K=3
+      signature_keypair: pqcrystals_kyber768_ref_keypair
+      signature_enc: pqcrystals_kyber768_ref_enc
+      signature_dec: pqcrystals_kyber768_ref_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c fips202.c
+    - name: avx2
+      version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
+      compile_opts: -DKYBER_K=3
+      signature_keypair: pqcrystals_kyber768_avx2_keypair
+      signature_enc: pqcrystals_kyber768_avx2_enc
+      signature_dec: pqcrystals_kyber768_avx2_dec
+      sources: LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h fips202x4.c keccak4x symmetric-shake.c
+      supported_platforms:
+        - architecture: x86_64
+          operating_systems:
+            - Linux
+            - Darwin
+          required_flags:
+            - avx2
+            - bmi2
+            - popcnt

--- a/avx2/sha2.h
+++ b/avx2/sha2.h
@@ -1,0 +1,9 @@
+#ifndef SHA_2_H
+#define SHA_2_H
+
+#include <openssl/sha.h>
+
+#define sha256(OUT, IN, INBYTES) SHA256(IN, INBYTES, OUT)
+#define sha512(OUT, IN, INBYTES) SHA512(IN, INBYTES, OUT)
+
+#endif

--- a/avx2/symmetric.h
+++ b/avx2/symmetric.h
@@ -7,7 +7,7 @@
 
 #ifdef KYBER_90S
 
-#include <openssl/sha.h>
+#include "sha2.h"
 #include "aes256ctr.h"
 
 #if (KYBER_SSBYTES != 32)
@@ -18,15 +18,15 @@ typedef aes256ctr_ctx xof_state;
 
 #define XOF_BLOCKBYTES AES256CTR_BLOCKBYTES
 
-#define hash_h(OUT, IN, INBYTES) SHA256(IN, INBYTES, OUT)
-#define hash_g(OUT, IN, INBYTES) SHA512(IN, INBYTES, OUT)
+#define hash_h(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
+#define hash_g(OUT, IN, INBYTES) sha512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, SEED, X, Y) \
         aes256ctr_init(STATE, SEED, (X) | ((uint16_t)(Y) << 8))
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) \
         aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) \
         aes256ctr_prf(OUT, OUTBYTES, KEY, NONCE)
-#define kdf(OUT, IN, INBYTES) SHA256(IN, INBYTES, OUT)
+#define kdf(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
 
 #else
 


### PR DESCRIPTION
.yml definitions:
- makes sure all necessary sources are included
- corrects claimed-nist-level for Kyber768/90s and Kyber1024/90s
- removes aes as required flags for non-90s versions
- updates nistkat-sha256 fields: only one entry is hashed, obtained with 'cat PQCkemKAT_<x>.rsp | head -n 8 | tail -n 6 | sha256sum'

Avoids direct calls to openssl sha2 API in the avx2 code. Instead, the calls are abstracted in avx2/sha2.h.