### PR TITLE
Adding .yml for common dependencies / namespacing

### DIFF
--- a/Common_META.yml
+++ b/Common_META.yml
@@ -1,0 +1,36 @@
+commons:
+  - name: common_ref
+    folder_name: ref
+    sources: aes256ctr.c aes256ctr.h fips202.c fips202.h
+  - name: common_aes
+    folder_name: avx2
+    sources: aes256ctr.c aes256ctr.h
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - aes
+          - sse2
+          - ssse3
+  - name: common_avx2
+    folder_name: avx2
+    sources: fips202.c fips202.h fips202x4.c fips202x4.h
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - avx2
+  - name: common_keccak4x_avx2
+    folder_name: avx2
+    sources: fips202x4.h keccak4x/KeccakP-1600-times4-SIMD256.c keccak4x/KeccakP-1600-times4-SnP.h keccak4x/KeccakP-1600-unrolling.macros keccak4x/KeccakP-SIMD256-config.h keccak4x/KeccakP-align.h keccak4x/KeccakP-brg_endian.h
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - avx2

--- a/Kyber1024-90s_META.yml
+++ b/Kyber1024-90s_META.yml
@@ -28,14 +28,16 @@ implementations:
     signature_keypair: pqcrystals_kyber1024_90s_ref_keypair
     signature_enc: pqcrystals_kyber1024_90s_ref_enc
     signature_dec: pqcrystals_kyber1024_90s_ref_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h aes256ctr.c symmetric-aes.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h symmetric-aes.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
     compile_opts: -DKYBER_K=4 -DKYBER_90S
     signature_keypair: pqcrystals_kyber1024_90s_avx2_keypair
     signature_enc: pqcrystals_kyber1024_90s_avx2_enc
     signature_dec: pqcrystals_kyber1024_90s_avx2_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h aes256ctr.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h
+    common_dep: common_avx2 common_aes
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Kyber1024_META.yml
+++ b/Kyber1024_META.yml
@@ -29,13 +29,15 @@ implementations:
     signature_enc: pqcrystals_kyber1024_ref_enc
     signature_dec: pqcrystals_kyber1024_ref_dec
     sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
     compile_opts: -DKYBER_K=4
     signature_keypair: pqcrystals_kyber1024_avx2_keypair
     signature_enc: pqcrystals_kyber1024_avx2_enc
     signature_dec: pqcrystals_kyber1024_avx2_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h fips202x4.c keccak4x symmetric-shake.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h symmetric-shake.c
+    common_dep: common_avx2 common_keccak4x_avx2
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Kyber512-90s_META.yml
+++ b/Kyber512-90s_META.yml
@@ -28,14 +28,16 @@ implementations:
     signature_keypair: pqcrystals_kyber512_90s_ref_keypair
     signature_enc: pqcrystals_kyber512_90s_ref_enc
     signature_dec: pqcrystals_kyber512_90s_ref_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h aes256ctr.c symmetric-aes.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h symmetric-aes.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
     compile_opts: -DKYBER_K=2 -DKYBER_90S
     signature_keypair: pqcrystals_kyber512_90s_avx2_keypair
     signature_enc: pqcrystals_kyber512_90s_avx2_enc
     signature_dec: pqcrystals_kyber512_90s_avx2_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h aes256ctr.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h
+    common_dep: common_avx2 common_aes
     supported_platforms:
         - architecture: x86_64
           operating_systems:

--- a/Kyber512_META.yml
+++ b/Kyber512_META.yml
@@ -29,13 +29,15 @@ implementations:
     signature_enc: pqcrystals_kyber512_ref_enc
     signature_dec: pqcrystals_kyber512_ref_dec
     sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
     compile_opts: -DKYBER_K=2 
     signature_keypair: pqcrystals_kyber512_avx2_keypair
     signature_enc: pqcrystals_kyber512_avx2_enc
     signature_dec: pqcrystals_kyber512_avx2_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h fips202x4.c keccak4x symmetric-shake.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h symmetric-shake.c
+    common_dep: common_avx2 common_keccak4x_avx2
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Kyber768-90s_META.yml
+++ b/Kyber768-90s_META.yml
@@ -28,14 +28,16 @@ implementations:
     signature_keypair: pqcrystals_kyber768_90s_ref_keypair
     signature_enc: pqcrystals_kyber768_90s_ref_enc
     signature_dec: pqcrystals_kyber768_90s_ref_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h aes256ctr.c symmetric-aes.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h aes256ctr.h symmetric-aes.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
     compile_opts: -DKYBER_K=3 -DKYBER_90S
     signature_keypair: pqcrystals_kyber768_90s_avx2_keypair
     signature_enc: pqcrystals_kyber768_90s_avx2_enc
     signature_dec: pqcrystals_kyber768_90s_avx2_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h aes256ctr.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h aes256ctr.h
+    common_dep: common_avx2 common_aes
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Kyber768_META.yml
+++ b/Kyber768_META.yml
@@ -28,14 +28,15 @@ implementations:
     signature_keypair: pqcrystals_kyber768_ref_keypair
     signature_enc: pqcrystals_kyber768_ref_enc
     signature_dec: pqcrystals_kyber768_ref_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c fips202.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
   - name: avx2
     version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
     compile_opts: -DKYBER_K=3
     signature_keypair: pqcrystals_kyber768_avx2_keypair
     signature_enc: pqcrystals_kyber768_avx2_enc
     signature_dec: pqcrystals_kyber768_avx2_dec
-    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h fips202x4.c keccak4x symmetric-shake.c
+    sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c fq.S shuffle.S ntt.S invntt.S basemul.S consts.c rejsample.c cbd.c verify.c align.h kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h fq.inc shuffle.inc ntt.h consts.h rejsample.h cbd.h verify.h symmetric.h fips202.h fips202x4.h symmetric-shake.c
+    common_dep: common_avx2 common_keccak4x_avx2
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/avx2/aes256ctr.h
+++ b/avx2/aes256ctr.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <immintrin.h>
 
-#define AES256CTR_NAMESPACE(s) pqcrystals_aes256ctr_avx2_##s
+#define AES256CTR_NAMESPACE(s) pqcrystals_kyber_aes256ctr_avx2_##s
 
 #define AES256CTR_BLOCKBYTES 64
 

--- a/avx2/fips202.h
+++ b/avx2/fips202.h
@@ -1,1 +1,54 @@
-../ref/fips202.h
+#ifndef FIPS202_H
+#define FIPS202_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SHAKE128_RATE 168
+#define SHAKE256_RATE 136
+#define SHA3_256_RATE 136
+#define SHA3_512_RATE 72
+
+#define FIPS202_NAMESPACE(s) pqcrystals_kyber_fips202_avx2_##s
+
+typedef struct {
+    uint64_t s[25];
+    unsigned int pos;
+} keccak_state;
+
+#define shake128_init FIPS202_NAMESPACE(shake128_init)
+void shake128_init(keccak_state *state);
+#define shake128_absorb FIPS202_NAMESPACE(shake128_absorb)
+void shake128_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_finalize FIPS202_NAMESPACE(shake128_finalize)
+void shake128_finalize(keccak_state *state);
+#define shake128_squeeze FIPS202_NAMESPACE(shake128_squeeze)
+void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake128_absorb_once FIPS202_NAMESPACE(shake128_absorb_once)
+void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
+void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state);
+
+#define shake256_init FIPS202_NAMESPACE(shake256_init)
+void shake256_init(keccak_state *state);
+#define shake256_absorb FIPS202_NAMESPACE(shake256_absorb)
+void shake256_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_finalize FIPS202_NAMESPACE(shake256_finalize)
+void shake256_finalize(keccak_state *state);
+#define shake256_squeeze FIPS202_NAMESPACE(shake256_squeeze)
+void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake256_absorb_once FIPS202_NAMESPACE(shake256_absorb_once)
+void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_squeezeblocks FIPS202_NAMESPACE(shake256_squeezeblocks)
+void shake256_squeezeblocks(uint8_t *out, size_t nblocks,  keccak_state *state);
+
+#define shake128 FIPS202_NAMESPACE(shake128)
+void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define shake256 FIPS202_NAMESPACE(shake256)
+void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define sha3_256 FIPS202_NAMESPACE(sha3_256)
+void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen);
+#define sha3_512 FIPS202_NAMESPACE(sha3_512)
+void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen);
+
+#endif

--- a/avx2/fips202x4.h
+++ b/avx2/fips202x4.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <immintrin.h>
 
-#define FIPS202X4_NAMESPACE(s) pqcrystals_fips202x4_avx2_##s
+#define FIPS202X4_NAMESPACE(s) pqcrystals_kyber_fips202x4_avx2_##s
 
 typedef struct {
   __m256i s[25];

--- a/ref/aes256ctr.h
+++ b/ref/aes256ctr.h
@@ -6,7 +6,7 @@
 
 #define AES256CTR_BLOCKBYTES 64
 
-#define AES256CTR_NAMESPACE(s) pqcrystals_aes256ctr_ref_##s
+#define AES256CTR_NAMESPACE(s) pqcrystals_kyber_aes256ctr_ref_##s
 
 typedef struct {
   uint64_t sk_exp[120];

--- a/ref/fips202.h
+++ b/ref/fips202.h
@@ -9,7 +9,7 @@
 #define SHA3_256_RATE 136
 #define SHA3_512_RATE 72
 
-#define FIPS202_NAMESPACE(s) pqcrystals_fips202_ref_##s
+#define FIPS202_NAMESPACE(s) pqcrystals_kyber_fips202_ref_##s
 
 typedef struct {
   uint64_t s[25];


### PR DESCRIPTION
- Added Commons_META.yml to define common dependencies for implementations and parameter sets.

- Made namespaces for fips202, fips202x4, aes256ctr etc more distinctive to avoid collisions when both kyber and dilithium are linked at the same time.