### PR TITLE
Elim unused param and use getrandom API.

### DIFF
--- a/ref/PQCgenKAT_kem.c
+++ b/ref/PQCgenKAT_kem.c
@@ -50,7 +50,7 @@ main()
     for (int i=0; i<48; i++)
         entropy_input[i] = i;
 
-    randombytes_init(entropy_input, NULL, 256);
+    randombytes_init(entropy_input, NULL);
     for (int i=0; i<100; i++) {
         fprintf(fp_req, "count = %d\n", i);
         randombytes(seed, 48);
@@ -85,7 +85,7 @@ main()
         }
         fprintBstr(fp_rsp, "seed = ", seed, 48);
 
-        randombytes_init(seed, NULL, 256);
+        randombytes_init(seed, NULL);
 
         // Generate the public/private keypair
         if ( (ret_val = crypto_kem_keypair(pk, sk)) != 0) {

--- a/ref/randombytes.c
+++ b/ref/randombytes.c
@@ -12,7 +12,7 @@
 #ifdef __linux__
 #define _GNU_SOURCE
 #include <unistd.h>
-#include <sys/syscall.h>
+#include <sys/random.h>
 #else
 #include <unistd.h>
 #endif
@@ -38,12 +38,12 @@ void randombytes(uint8_t *out, size_t outlen) {
   if(!CryptReleaseContext(ctx, 0))
     abort();
 }
-#elif defined(__linux__) && defined(SYS_getrandom)
+#elif defined(__linux__) && defined(__GLIBC__) && ((__GLIBC__ > 2) || (__GLIBC_MINOR__ > 24))
 void randombytes(uint8_t *out, size_t outlen) {
   ssize_t ret;
 
   while(outlen > 0) {
-    ret = syscall(SYS_getrandom, out, outlen, 0);
+    ret = getrandom (out, outlen, 0);
     if(ret == -1 && errno == EINTR)
       continue;
     else if(ret == -1)

--- a/ref/rng.c
+++ b/ref/rng.c
@@ -137,8 +137,7 @@ AES256_ECB(unsigned char *key, unsigned char *ctr, unsigned char *buffer)
 
 void
 randombytes_init(unsigned char *entropy_input,
-                 unsigned char *personalization_string,
-                 int security_strength)
+                 unsigned char *personalization_string)
 {
     unsigned char   seed_material[48];
 

--- a/ref/rng.h
+++ b/ref/rng.h
@@ -46,8 +46,7 @@ seedexpander(AES_XOF_struct *ctx, unsigned char *x, unsigned long xlen);
 
 void
 randombytes_init(unsigned char *entropy_input,
-                 unsigned char *personalization_string,
-                 int security_strength);
+                 unsigned char *personalization_string);
 
 int
 randombytes(unsigned char *x, unsigned long long xlen);


### PR DESCRIPTION
The function randombytes_init included an unused parameter which has been removed. 
In 2017, glibc added an API call for getrandom.  This update checks the glibc version and uses the getrandom API call if available instead of making a syscall.