### PR TITLE
Remove last unused nonce update in indcpa_enc (90s)

### DIFF
--- a/avx2/indcpa.c
+++ b/avx2/indcpa.c
@@ -568,8 +568,6 @@ void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
     poly_cbd_eta2(&ep.vec[i], buf.vec);
   }
   aes256ctr_squeezeblocks(buf.coeffs, CIPHERTEXTNOISE_NBLOCKS, &state);
-  state.n = _mm_loadl_epi64((__m128i *)&nonce);
-  nonce += 1;
   poly_cbd_eta2(&epp, buf.vec);
 #else
 #if KYBER_K == 2


### PR DESCRIPTION
The last nonce update in indcpa_enc of the 90s version is unused and can be removed.
Detected using scan-build on OQS:
https://github.com/open-quantum-safe/liboqs/pull/1240
https://circleci.com/api/v1.1/project/github/open-quantum-safe/liboqs/17515/output/103/0?file=true&allocation-id=62bb17df947e861ada3206ce-0-build%2F54D6229E