### PR TITLE
Add a value barrier on the `cmov` control flag

### DIFF
--- a/avx2/verify.c
+++ b/avx2/verify.c
@@ -57,6 +57,16 @@ void cmov(uint8_t * restrict r, const uint8_t *x, size_t len, uint8_t b)
   size_t i;
   __m256i xvec, rvec, bvec;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   bvec = _mm256_set1_epi64x(-(uint64_t)b);
   for(i=0;i<len/32;i++) {
     rvec = _mm256_loadu_si256((__m256i *)&r[32*i]);

--- a/ref/verify.c
+++ b/ref/verify.c
@@ -41,6 +41,16 @@ void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b)
 {
   size_t i;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   b = -b;
   for(i=0;i<len;i++)
     r[i] ^= b & (r[i] ^ x[i]);


### PR DESCRIPTION
Peter and I were discussing whether it is safe to use boolean negation to produce the control flag for `cmov`, e.g.
```c
  cmov(ss,kr,KYBER_SYMBYTES,!fail);
```
as he has done [here](https://github.com/pq-crystals/kyber/blob/a440ac9901e16564d426be9df009a9e3ae05bbf7/ref/kem.c#L167). The risk is that the compiler may infer that `!fail` is 0/1 valued and then handle the two cases with a branch.

Crucially, this is only a problem if `cmov` can be inlined into `decaps`, and this can't happen given
- the current factorization into `verify.c` and `kem.c`, and
- the fact that we don't enable link-time optimization.

But I'm worried that downstream consumers of this code might concatenate the source files before compilation.

The value barrier used here is the same countermeasure that [BoringSSL used]((https://boringssl.googlesource.com/boringssl/+/92b7c89e6e8ba82924b57153bea68241cc45f658)) when clang started to recognize `(mask & x) | (~mask & y)` as selecting between `x` and `y`. For what it's worth, compilers don't (yet) seem to recognize `x ^ (mask & (x ^ y))`, or the pattern in `avx2/verify.c`, as selecting between `x` and `y`.