### PR TITLE
update .yml files

### DIFF
--- a/Kyber1024_META.yml
+++ b/Kyber1024_META.yml
@@ -6,8 +6,8 @@ length-public-key: 1568
 length-ciphertext: 1568
 length-secret-key: 3168
 length-shared-secret: 32
-nistkat-sha256: 5afcf2a568ad32d49b55105b032af1850f03f3888ff9e2a72f4059c58e968f60
-testvectors-sha256: ff1a854b9b6761a70c65ccae85246fe0596a949e72eae0866a8a2a2d4ea54b10
+nistkat-sha256: 03d6494b74c45d010e61b0328c1ab318c4df3b7f9dbd04d0e35b3468848584b7
+testvectors-sha256: 85ab251d6e749e6b27507a8a6ec473ba2e8419c1aef87d0cd5ec9903c1bb92df
 principal-submitters:
   - Peter Schwabe
 auxiliary-submitters:
@@ -22,7 +22,7 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff
+    version: https://github.com/pq-crystals/kyber/tree/standard
     folder_name: ref
     compile_opts: -DKYBER_K=4
     signature_keypair: pqcrystals_kyber1024_ref_keypair
@@ -31,7 +31,7 @@ implementations:
     sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
     common_dep: common_ref
   - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff
+    version: https://github.com/pq-crystals/kyber/tree/standard
     compile_opts: -DKYBER_K=4
     signature_keypair: pqcrystals_kyber1024_avx2_keypair
     signature_enc: pqcrystals_kyber1024_avx2_enc

--- a/Kyber512_META.yml
+++ b/Kyber512_META.yml
@@ -6,8 +6,8 @@ length-public-key: 800
 length-ciphertext: 768
 length-secret-key: 1632
 length-shared-secret: 32
-nistkat-sha256: bb0481d3325d828817900b709d23917cefbc10026fc857f098979451f67bb0ca
-testvectors-sha256: 6730bb552c22d9d2176ffb5568e48eb30952cf1f065073ec5f9724f6a3c6ea85
+nistkat-sha256: 76aae1fa3f8367522700b22da635a5bc4ced4298edb0eb9947aa3ba60d62676f
+testvectors-sha256: e1ac6fb45e2511f4170a3527c0c50dcd61336f47113df7a299a61ef8394bd669
 principal-submitters:
   - Peter Schwabe
 auxiliary-submitters:
@@ -22,7 +22,7 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b
+    version: https://github.com/pq-crystals/kyber/tree/standard
     folder_name: ref
     compile_opts: -DKYBER_K=2 
     signature_keypair: pqcrystals_kyber512_ref_keypair
@@ -31,7 +31,7 @@ implementations:
     sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
     common_dep: common_ref
   - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/36414d64fc1890ed58d1ca8b1e0cab23635d1ac2
+    version: https://github.com/pq-crystals/kyber/tree/standard
     compile_opts: -DKYBER_K=2 
     signature_keypair: pqcrystals_kyber512_avx2_keypair
     signature_enc: pqcrystals_kyber512_avx2_enc

--- a/Kyber768_META.yml
+++ b/Kyber768_META.yml
@@ -6,8 +6,8 @@ length-public-key: 1184
 length-ciphertext: 1088
 length-secret-key: 2400
 length-shared-secret: 32
-nistkat-sha256: 89e82a5bf2d4ddb2c6444e10409e6d9ca65dafbca67d1a0db2c9b54920a29172
-testvectors-sha256: 667c8ca2ca93729c0df6ff24588460bad1bbdbfb64ece0fe8563852a7ff348c6
+nistkat-sha256: c7e76b4b30c786b5b70c152a446e7832c1cb42b3816ec048dbeaf7041211b310
+testvectors-sha256: 2586721a714c439f6fef26e29ee1c4c67c6207186f810617f278e6ce3e67ea0d
 principal-submitters:
   - Peter Schwabe
 auxiliary-submitters:
@@ -22,7 +22,7 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff
+    version: https://github.com/pq-crystals/kyber/tree/standard
     folder_name: ref
     compile_opts: -DKYBER_K=3
     signature_keypair: pqcrystals_kyber768_ref_keypair
@@ -31,7 +31,7 @@ implementations:
     sources: ../LICENSE kem.c indcpa.c polyvec.c poly.c reduce.c ntt.c cbd.c verify.c kem.h params.h api.h indcpa.h polyvec.h poly.h reduce.h ntt.h cbd.h verify.h symmetric.h fips202.h symmetric-shake.c
     common_dep: common_ref
   - name: avx2
-    version: https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff
+    version: https://github.com/pq-crystals/kyber/tree/standard
     compile_opts: -DKYBER_K=3
     signature_keypair: pqcrystals_kyber768_avx2_keypair
     signature_enc: pqcrystals_kyber768_avx2_enc


### PR DESCRIPTION
Updates yml files (test vector / kat hashes) for the standard version. In preparation for downstream inclusion in liboqs (https://github.com/open-quantum-safe/liboqs/pull/1537).