### PR TITLE
Add (void) to function prototypes in test_kyber.c

### DIFF
--- a/ref/test_kyber.c
+++ b/ref/test_kyber.c
@@ -6,7 +6,7 @@
 
 #define NTESTS 1000
 
-static int test_keys()
+static int test_keys(void)
 {
   uint8_t pk[CRYPTO_PUBLICKEYBYTES];
   uint8_t sk[CRYPTO_SECRETKEYBYTES];
@@ -31,7 +31,7 @@ static int test_keys()
   return 0;
 }
 
-static int test_invalid_sk_a()
+static int test_invalid_sk_a(void)
 {
   uint8_t pk[CRYPTO_PUBLICKEYBYTES];
   uint8_t sk[CRYPTO_SECRETKEYBYTES];
@@ -59,7 +59,7 @@ static int test_invalid_sk_a()
   return 0;
 }
 
-static int test_invalid_ciphertext()
+static int test_invalid_ciphertext(void)
 {
   uint8_t pk[CRYPTO_PUBLICKEYBYTES];
   uint8_t sk[CRYPTO_SECRETKEYBYTES];


### PR DESCRIPTION
The following compilation errors occur without this change which is default on current clang release (macos)
kyber/ref/test_kyber.c:62:35: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
