### PR TITLE
backport the security patch of CVE-2024-37880

### DIFF
--- a/ref/poly.c
+++ b/ref/poly.c
@@ -5,6 +5,7 @@
 #include "reduce.h"
 #include "cbd.h"
 #include "symmetric.h"
+#include "verify.h"
 
 /*************************************************
 * Name:        poly_compress
@@ -174,8 +175,8 @@ void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES])
 
   for(i=0;i<KYBER_N/8;i++) {
     for(j=0;j<8;j++) {
-      mask = -(int16_t)((msg[i] >> j)&1);
-      r->coeffs[8*i+j] = mask & ((KYBER_Q+1)/2);
+      r->coeffs[8*i+j] = 0;
+      cmov_int16(r->coeffs+8*i+j, ((KYBER_Q+1)/2), (msg[i] >> j)&1);
     }
   }
 }

--- a/ref/verify.c
+++ b/ref/verify.c
@@ -45,3 +45,9 @@ void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b)
   for(i=0;i<len;i++)
     r[i] ^= b & (r[i] ^ x[i]);
 }
+
+void cmov_int16(int16_t *r, int16_t v, uint16_t b)
+{
+  b = -b;
+  *r ^= b & ((*r) ^ v);
+}

--- a/ref/verify.h
+++ b/ref/verify.h
@@ -10,5 +10,8 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len);
 
 #define cmov KYBER_NAMESPACE(cmov)
 void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b);
+#define cmov_int16 KYBER_NAMESPACE(cmov_int16)
+void cmov_int16(int16_t *r, int16_t v, uint16_t b);
+
 
 #endif


### PR DESCRIPTION
Here is a vulnerability which is fixed in the main branch which is https://github.com/pq-crystals/kyber/commit/9b8d30698a3e7449aeb34e62339d4176f11e3c6c, but is not fixed in the branch of deterministic_api, maybe it should be backported?