### PR TITLE
Correct buffer size of re-encrypted ciphertext in `crypto_kem_dec`

### DIFF
--- a/ref/kem.c
+++ b/ref/kem.c
@@ -145,7 +145,7 @@ int crypto_kem_dec(uint8_t *ss,
   uint8_t buf[2*KYBER_SYMBYTES];
   /* Will contain key, coins */
   uint8_t kr[2*KYBER_SYMBYTES];
-  uint8_t cmp[KYBER_CIPHERTEXTBYTES+KYBER_SYMBYTES];
+  uint8_t cmp[KYBER_CIPHERTEXTBYTES];
   const uint8_t *pk = sk+KYBER_INDCPA_SECRETKEYBYTES;
 
   indcpa_dec(buf, ct, sk);


### PR DESCRIPTION
The re-encrypted ciphertext has `KYBER_CIPHERTEXTBYTES` bytes. For some reason the current code adds `KYBER_SYMBYTES` to that for now reason.
I suspect this buffer was used before to compute the rejection key as well, but that got moved to a separate function in the meantime. 