### PR TITLE
Add SPDX headers and copyright notices at the beginning of files.

### DIFF
--- a/avx2/align.h
+++ b/avx2/align.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef ALIGN_H
 #define ALIGN_H
 

--- a/avx2/api.h
+++ b/avx2/api.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef API_H
 #define API_H
 

--- a/avx2/basemul.S
+++ b/avx2/basemul.S
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include "consts.h"
 
 .macro schoolbook off

--- a/avx2/cbd.c
+++ b/avx2/cbd.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include <immintrin.h>
 #include "params.h"

--- a/avx2/cbd.h
+++ b/avx2/cbd.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef CBD_H
 #define CBD_H
 

--- a/avx2/consts.c
+++ b/avx2/consts.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include "align.h"
 #include "params.h"
 #include "consts.h"

--- a/avx2/consts.h
+++ b/avx2/consts.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef CONSTS_H
 #define CONSTS_H
 

--- a/avx2/fips202.h
+++ b/avx2/fips202.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef FIPS202_H
 #define FIPS202_H
 

--- a/avx2/fips202x4.c
+++ b/avx2/fips202x4.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <immintrin.h>

--- a/avx2/fips202x4.h
+++ b/avx2/fips202x4.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef FIPS202X4_H
 #define FIPS202X4_H
 

--- a/avx2/fq.S
+++ b/avx2/fq.S
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include "consts.h"
 .include "fq.inc"
 

--- a/avx2/fq.inc
+++ b/avx2/fq.inc
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 .macro red16 r,rs=0,x=12
 vpmulhw         %ymm1,%ymm\r,%ymm\x
 .if \rs

--- a/avx2/indcpa.c
+++ b/avx2/indcpa.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <immintrin.h>

--- a/avx2/invntt.S
+++ b/avx2/invntt.S
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include "consts.h"
 .include "shuffle.inc"
 .include "fq.inc"

--- a/avx2/keccak4x/KeccakP-1600-times4-SIMD256.c
+++ b/avx2/keccak4x/KeccakP-1600-times4-SIMD256.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0
+ * Copyright: Keccak, Keyak and Ketje Teams, namely, Guido Bertoni, Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/avx2/keccak4x/KeccakP-1600-times4-SnP.h
+++ b/avx2/keccak4x/KeccakP-1600-times4-SnP.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0
+ * Copyright: Keccak, Keyak and Ketje Teams, namely, Guido Bertoni, Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/avx2/keccak4x/KeccakP-1600-unrolling.macros
+++ b/avx2/keccak4x/KeccakP-1600-unrolling.macros
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0
+ * Copyright: Keccak, Keyak and Ketje Teams, namely, Guido Bertoni, Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/avx2/keccak4x/KeccakP-SIMD256-config.h
+++ b/avx2/keccak4x/KeccakP-SIMD256-config.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0
+ * Copyright: Keccak, Keyak and Ketje Teams, namely, Guido Bertoni, Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer
+ * */
+
 #define KeccakP1600times4_implementation_config "AVX2, all rounds unrolled"
 #define KeccakP1600times4_fullUnrolling
 #define KeccakP1600times4_useAVX2

--- a/avx2/keccak4x/KeccakP-align.h
+++ b/avx2/keccak4x/KeccakP-align.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: CC0-1.0
+ * Copyright: Keccak, Keyak and Ketje Teams, namely, Guido Bertoni, Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer
+ * */
+
 /*
 Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
 Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby

--- a/avx2/ntt.S
+++ b/avx2/ntt.S
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include "consts.h"
 .include "shuffle.inc"
 

--- a/avx2/ntt.h
+++ b/avx2/ntt.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef NTT_H
 #define NTT_H
 

--- a/avx2/params.h
+++ b/avx2/params.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef PARAMS_H
 #define PARAMS_H
 

--- a/avx2/poly.c
+++ b/avx2/poly.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include <immintrin.h>
 #include <string.h>

--- a/avx2/poly.h
+++ b/avx2/poly.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef POLY_H
 #define POLY_H
 

--- a/avx2/polyvec.c
+++ b/avx2/polyvec.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include <immintrin.h>
 #include <string.h>

--- a/avx2/polyvec.h
+++ b/avx2/polyvec.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef POLYVEC_H
 #define POLYVEC_H
 

--- a/avx2/reduce.h
+++ b/avx2/reduce.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef REDUCE_H
 #define REDUCE_H
 

--- a/avx2/rejsample.c
+++ b/avx2/rejsample.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include <immintrin.h>
 #include <string.h>

--- a/avx2/rejsample.h
+++ b/avx2/rejsample.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef REJSAMPLE_H
 #define REJSAMPLE_H
 

--- a/avx2/shuffle.S
+++ b/avx2/shuffle.S
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include "consts.h"
 .include "fq.inc"
 .include "shuffle.inc"

--- a/avx2/shuffle.inc
+++ b/avx2/shuffle.inc
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 .macro shuffle8 r0,r1,r2,r3
 vperm2i128	$0x20,%ymm\r1,%ymm\r0,%ymm\r2
 vperm2i128	$0x31,%ymm\r1,%ymm\r0,%ymm\r3

--- a/avx2/symmetric.h
+++ b/avx2/symmetric.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef SYMMETRIC_H
 #define SYMMETRIC_H
 

--- a/avx2/verify.c
+++ b/avx2/verify.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <immintrin.h>

--- a/ref/api.h
+++ b/ref/api.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef API_H
 #define API_H
 

--- a/ref/cbd.c
+++ b/ref/cbd.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include "params.h"
 #include "cbd.h"

--- a/ref/cbd.h
+++ b/ref/cbd.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef CBD_H
 #define CBD_H
 

--- a/ref/fips202.c
+++ b/ref/fips202.c
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, Gregor Seiler, Peter Schwabe, Damien Stehlé,
+ *            Ronny Van Keer (crypto_hash/keccakc512/simple/ from http://bench.cr.yp.to/supercop.html),
+ *            Gilles Van Assche, Daniel J. Bernstein, Peter Schwabe (TweetFips202)
+ * */
+
 /* Based on the public domain implementation in crypto_hash/keccakc512/simple/ from
  * http://bench.cr.yp.to/supercop.html by Ronny Van Keer and the public domain "TweetFips202"
  * implementation from https://twitter.com/tweetfips202 by Gilles Van Assche, Daniel J. Bernstein,

--- a/ref/fips202.h
+++ b/ref/fips202.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef FIPS202_H
 #define FIPS202_H
 

--- a/ref/indcpa.c
+++ b/ref/indcpa.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/ref/indcpa.h
+++ b/ref/indcpa.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef INDCPA_H
 #define INDCPA_H
 

--- a/ref/kem.c
+++ b/ref/kem.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/ref/kem.h
+++ b/ref/kem.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef KEM_H
 #define KEM_H
 

--- a/ref/ntt.c
+++ b/ref/ntt.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include "params.h"
 #include "ntt.h"

--- a/ref/ntt.h
+++ b/ref/ntt.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef NTT_H
 #define NTT_H
 

--- a/ref/params.h
+++ b/ref/params.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef PARAMS_H
 #define PARAMS_H
 

--- a/ref/poly.c
+++ b/ref/poly.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include "params.h"
 #include "poly.h"

--- a/ref/poly.h
+++ b/ref/poly.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef POLY_H
 #define POLY_H
 

--- a/ref/polyvec.c
+++ b/ref/polyvec.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include "params.h"
 #include "poly.h"

--- a/ref/polyvec.h
+++ b/ref/polyvec.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef POLYVEC_H
 #define POLYVEC_H
 

--- a/ref/randombytes.c
+++ b/ref/randombytes.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/ref/randombytes.h
+++ b/ref/randombytes.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef RANDOMBYTES_H
 #define RANDOMBYTES_H
 

--- a/ref/reduce.c
+++ b/ref/reduce.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include "params.h"
 #include "reduce.h"

--- a/ref/reduce.h
+++ b/ref/reduce.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef REDUCE_H
 #define REDUCE_H
 

--- a/ref/symmetric-shake.c
+++ b/ref/symmetric-shake.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/ref/symmetric.h
+++ b/ref/symmetric.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef SYMMETRIC_H
 #define SYMMETRIC_H
 

--- a/ref/test/cpucycles.c
+++ b/ref/test/cpucycles.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stdint.h>
 #include "cpucycles.h"
 

--- a/ref/test/cpucycles.h
+++ b/ref/test/cpucycles.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef CPUCYCLES_H
 #define CPUCYCLES_H
 

--- a/ref/test/speed_print.c
+++ b/ref/test/speed_print.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/ref/test/speed_print.h
+++ b/ref/test/speed_print.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef PRINT_SPEED_H
 #define PRINT_SPEED_H
 

--- a/ref/test/test_kyber.c
+++ b/ref/test/test_kyber.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>

--- a/ref/test/test_speed.c
+++ b/ref/test/test_speed.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/ref/verify.c
+++ b/ref/verify.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #include <stddef.h>
 #include <stdint.h>
 #include "verify.h"

--- a/ref/verify.h
+++ b/ref/verify.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 OR CC0-1.0
+ * Copyright: Joppe Bos, Léo Ducas, Eike Kiltz, Tancrède Lepoint, Vadim Lyubashevsky, John Schanck, Peter Schwabe, Gregor Seiler, Damien Stehlé
+ * */
+
 #ifndef VERIFY_H
 #define VERIFY_H
 


### PR DESCRIPTION
In downstream projects, files may be copied and moved around. This makes it difficult to track the copyrights and licenses without having them stored in each file.

License and copyright holders for files without specific header is assumed to be the one in LICENSE and AUTHORS.md files respectively.

This is similar to pq-crystals/dilithium#99 and shares roughly the same limitation. This time I didn't copy the header for `ref/fips202.h` from `ref/fips202.c` however; this reflects how parted I am with this file: because the current statements and what I can guess (i.e. same as the `.c` file) differ. I guess this will need some back-and-forth before these MRs can be merged; I hope I can make that as seamless as possible.